### PR TITLE
Properly formatted image property on Debug luigi task

### DIFF
--- a/orchestrator/task.py
+++ b/orchestrator/task.py
@@ -14,7 +14,7 @@ class Debug(DockerTask):
 
     @property
     def image(self):
-        return 'code-challenge/download-data:{VERSION}'
+        return f'code-challenge/download-data:{VERSION}'
 
     @property
     def command(self):


### PR DESCRIPTION
When you try to run the debug task with
`docker-compose run orchestrator luigi --module task Debug --local-scheduler`

it fails with
> Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/docker/api/client.py", line 261, in _raise_for_status
    response.raise_for_status()
  File "/usr/local/lib/python3.6/site-packages/requests/models.py", line 941, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 400 Client Error: Bad Request for url: http+docker://localhost/v1.35/containers/create?name=debug-false-847ab9f492

because the image name of the Docker luigi task is not properly formatted.
